### PR TITLE
fix: remove broken tafsir id

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -7,7 +7,10 @@ if (process.env.NODE_ENV === "production") {
 }
 const defaultReaderSettings: ReaderSettings = {
   splitView: true,
-  left: [{ content: ["translation", "en", 22] }],
+  left: [
+    { content: ["translation", "en", 22] },
+    { content: ["tafsir", "en", 169] },
+  ],
   right: [
     { content: ["translation", "ar", "imlaei"] },
     { content: ["translation", "en", 57] },

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -7,10 +7,7 @@ if (process.env.NODE_ENV === "production") {
 }
 const defaultReaderSettings: ReaderSettings = {
   splitView: true,
-  left: [
-    { content: ["translation", "en", 22] },
-    { content: ["tafsir", "en", 171] },
-  ],
+  left: [{ content: ["translation", "en", 22] }],
   right: [
     { content: ["translation", "ar", "imlaei"] },
     { content: ["translation", "en", 57] },


### PR DESCRIPTION
The id of the ibn Kathir tafsir has changed on the API from 171 to 169. The default config was updated to reflect that.